### PR TITLE
chore: replace xmldom with @xmldom/xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
 		"access": "public"
 	},
 	"dependencies": {
+		"@xmldom/xmldom": "^0.8.1",
 		"axios": "^0.23.0",
 		"lodash": "^4.17.21",
 		"query-string": "^6.14.1",
-		"xmldom": "^0.6.0",
 		"xpath": "^0.0.32"
 	},
 	"devDependencies": {

--- a/src/translators/GoogleTranslator/index.ts
+++ b/src/translators/GoogleTranslator/index.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { stringify } from 'query-string';
 import xpath from 'xpath';
-import { DOMParser } from 'xmldom';
+import { DOMParser } from '@xmldom/xmldom';
 
 import { langCode, langCodeWithAuto, BaseTranslator } from '../../types/Translator';
 import { getToken } from './token';


### PR DESCRIPTION
This PR replaces the `xmldom` dependency with `@xmldom/xmldom`, and bumps the version to v0.8.1 (Latest version as of writing this PR).

**Reasons:**

1. Author no longer publishes to `xmldom`. 
Quote from author:

> Since version 0.7.0 this package is published to npm as [@xmldom/xmldom](https://www.npmjs.com/package/@xmldom/xmldom) and no longer as [xmldom](https://www.npmjs.com/package/xmldom), because [we are no longer able to publish xmldom](https://github.com/xmldom/xmldom/issues/271).

2. xmldom versions 0.6.0 and older do not correctly escape special characters when serializing elements removed from their ancestor. This may lead to unexpected syntactic changes during XML processing in some downstream applications.
