### PR TITLE
Google translator return translated text and original both as translation for some cases

### DIFF
--- a/src/translators/GoogleTranslator/index.ts
+++ b/src/translators/GoogleTranslator/index.ts
@@ -57,9 +57,11 @@ const parseXMLResponse = (text: string) => {
 	const nodesWithTranslation = xpath.select('//pre/*[not(self::i)]', doc);
 
 	if (nodesWithTranslation.length === 0) return null;
+	// console.log('Selected nodes', nodesWithTranslation.map((node) => (node as Node).toString()));
 	return nodesWithTranslation
 		.map((node) => {
-			const textNodes = xpath.select('//text()', node as Node);
+			// Select text in child nodes or in self
+			const textNodes = xpath.select('descendant-or-self::*/text()', node as Node);
 			if (textNodes.length > 1) {
 				console.debug('More than one text node found');
 			}

--- a/src/translators/__tests__/resources/text-middle.txt
+++ b/src/translators/__tests__/resources/text-middle.txt
@@ -1,0 +1,8 @@
+Linguist is a powerful browser extension that is ready to replace your favorite translation service.
+
+Translate web pages, highlighted text, Netflix subtitles, private messages, speak the translated text, and save important translations to your personal dictionary to learn words in 130 languages.
+Why Linguist?
+
+Unlike other browser extensions, Linguist is not just a wrapper over the Google Translator Widget; it's a full-featured and independent translation system. This is why with Linguist you can be private and translate texts offline on your device and use any translation service, even your own like ChatGPT. See a custom translators list to find bindings for the most popular translation services.
+
+Linguist is free, open-source, respects your privacy, and does not collect your personal data.

--- a/src/translators/__tests__/translators.test.ts
+++ b/src/translators/__tests__/translators.test.ts
@@ -52,6 +52,9 @@ const currentDir = path.dirname(__filename);
 const longTextForTest = readFileSync(
 	path.resolve(currentDir, 'resources/text-long.txt'),
 ).toString('utf8');
+const midTextForTest = readFileSync(
+	path.resolve(currentDir, 'resources/text-middle.txt'),
+).toString('utf8');
 
 const LONG_TEXT_TRANSLATION_TIMEOUT = 80000;
 
@@ -102,6 +105,38 @@ translatorsForTest.forEach(({ translator: translatorClass, options }) => {
 				expect(typeof translation).toBe('string');
 				expect(translation).toContain('мир');
 				expect(isStringStartFromLetter(translation)).toBeTruthy();
+			});
+		});
+
+		describe('Translate results are correct', () => {
+			const singleTexts = midTextForTest.split('\n').filter(Boolean);
+
+			test(`Batch translator call with single text, returns text that does not contains original text`, async () => {
+				const translator = new translatorClass(translatorOptions);
+				await translator
+					.translateBatch([midTextForTest], 'en', 'ru')
+					.then((translations) => {
+						translations.forEach((translation) => {
+							expect(typeof translation).toBe('string');
+							singleTexts.forEach((singleText) =>
+								expect(translation).not.toContain(singleText),
+							);
+						});
+					});
+			});
+
+			test(`Batch translator call with multiple texts, returns texts that does not contains original text`, async () => {
+				const translator = new translatorClass(translatorOptions);
+				await translator
+					.translateBatch([midTextForTest, midTextForTest], 'en', 'ru')
+					.then((translations) => {
+						translations.forEach((translation) => {
+							expect(typeof translation).toBe('string');
+							singleTexts.forEach((singleText) =>
+								expect(translation).not.toContain(singleText),
+							);
+						});
+					});
 			});
 		});
 


### PR DESCRIPTION
# The problem

It looks xpath selector `//` selects text nodes on document root, instead of in selected node

# The solution

Use xpath selector `descendant-or-self::*` to find text in node or its childs only