### PR TITLE
Added required "?" character at the end of corsproxy url

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ import { GoogleTranslator } from '@translate-tools/core/translators/GoogleTransl
 
 // Use some CORS proxy service as prefix
 const translator = new GoogleTranslator({
-	corsProxy: 'https://corsproxy.io/',
+	corsProxy: 'https://corsproxy.io/?',
 });
 
 // Or use your own transform function


### PR DESCRIPTION
Corsproxy url requires a "?" to work, otherwise you will receive a HTML Request error and a CORS proxy error.

Before changes:
![image](https://github.com/translate-tools/core/assets/128194780/8a246686-f305-400b-a1b1-57d94914912e)

After changes:
*Works as intended, no errors*

This PR is a fix for this thread https://github.com/translate-tools/core/issues/87#issuecomment-1960470731